### PR TITLE
#55 - Fix console toolbox theme change

### DIFF
--- a/lib/console/consoleOverlay.js
+++ b/lib/console/consoleOverlay.js
@@ -257,6 +257,7 @@ const ConsoleOverlay = Class(
     for (let button of buttons) {
       button.classList.remove("devtools-toolbarbutton");
       button.classList.remove("webconsole-filter-button");
+      button.classList.add("firebug-theme-mark")
     }
 
     Win.loaded(iframeWin).then(doc => {
@@ -283,7 +284,7 @@ const ConsoleOverlay = Class(
     let doc = iframeWin.document;
     let win = doc.getElementById("devtools-webconsole");
 
-    let buttons = doc.querySelectorAll(".devtools-toolbarbutton");
+    let buttons = doc.querySelectorAll(".firebug-theme-mark");
     for (let button of buttons) {
       button.classList.add("devtools-toolbarbutton");
       button.classList.add("webconsole-filter-button");
@@ -302,7 +303,7 @@ const ConsoleOverlay = Class(
     removeSheet(iframeWin, "chrome://firebug/skin/html.css", "author");
 
     //Theme.customizeSideBarSplitter(iframeWin, false);
-  },
+  }
 });
 
 // Exports from this module


### PR DESCRIPTION
The problem just was that the reference used to restore the element class is deleted when applying the firebug theme
