### PR TITLE
Issue 229 background colour of label change

### DIFF
--- a/chrome/skin/classic/shared/debugger.css
+++ b/chrome/skin/classic/shared/debugger.css
@@ -174,6 +174,14 @@
 }
 
 /******************************************************************************/
+/* Variables Panel */
+
+/* overwrite widget.css for issue #229*/
+.theme-firebug .variables-view-scope { 
+    -moz-user-focus: ignore;
+}
+
+/******************************************************************************/
 /* Callstack Panel */
 
 .theme-firebug #callstack-list {

--- a/chrome/skin/classic/shared/firebug-theme.css
+++ b/chrome/skin/classic/shared/firebug-theme.css
@@ -171,13 +171,6 @@
   border-color: #aaa;
 }
 
-/*overwrite widget.css to make sure the background colour on the variable view labels do not change*/
-
-.variables-view-scope{
-    -moz-user-focus:ignore;
-}
-
-
 .ruleview-colorswatch,
 .computedview-colorswatch,
 .ruleview-bezierswatch {


### PR DESCRIPTION
See https://github.com/firebug/firebug.next/issues/229 for more details. I have added to firebug-theme.css to ensure the the background colour of the label does not change on focus.
