### PR TITLE
Fixed 'JavaScript 1.7's let expressions are deprecated' errors

### DIFF
--- a/lib/net/export/har-builder.js
+++ b/lib/net/export/har-builder.js
@@ -340,13 +340,10 @@ function parseQueryString(aQueryString) {
   let paramsArray = aQueryString.replace(/^[?&]/, "").split("&").map(e =>
     {
       let param = e.split("=");
-
       let name = param[0] ? NetworkHelper.convertToUnicode(unescape(param[0])) : "";
-
       let value = param[1] ? NetworkHelper.convertToUnicode(unescape(param[1])) : "";
 
       return {name, value};
-     
     });
 
   return paramsArray;


### PR DESCRIPTION
JavaScript 1.7's let expressions are deprecated https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Non-standard_let_extensions