### PR TITLE
 #276 Debugger's location panel not showing pointer

### DIFF
--- a/chrome/skin/classic/shared/debugger.css
+++ b/chrome/skin/classic/shared/debugger.css
@@ -16,6 +16,10 @@
   padding: 2px;
 }
 
+.theme-firebug #sources-pane .side-menu-widget-item :-moz-any(label, hbox) {
+  cursor: pointer;
+}
+
 .theme-firebug #sources-pane .side-menu-widget-group-title {
   border-bottom: none;
   margin: 0;


### PR DESCRIPTION
To test:
1. go to google.
2. open the debugger panel
3 hover over the locations of the various resources and you shoudl get a pointer like a link