### PR TITLE
#286 Firebug not using the css var values

### DIFF
--- a/chrome/skin/classic/shared/firebug-style-variables.css
+++ b/chrome/skin/classic/shared/firebug-style-variables.css
@@ -1,0 +1,39 @@
+/* See license.txt for terms of usage */
+
+/**********************************************
+Description: This file includes all the CSS 
+  variables used across firebug theme.
+
+
+Usage: @import url("firebug-style-variables.css");
+
+**********************************************/
+
+:root {
+  --theme-body-background: #fcfcfc;
+  --theme-sidebar-background: #f7f7f7;
+  --theme-contrast-background: #e6b064;
+
+  --theme-tab-toolbar-background: #ebeced;
+  --theme-toolbar-background: #f0f1f2;
+  --theme-selection-background: #4c9ed9;
+  --theme-selection-color: #f5f7fa;
+  --theme-selection-background-semitransparent: rgba(76, 158, 217, .23);
+  --theme-splitter-color: #aaaaaa;
+  --theme-comment: hsl(90,2%,46%);
+
+  --theme-body-color: #18191a;
+  --theme-body-color-alt: #585959;
+  --theme-content-color1: #292e33;
+  --theme-content-color2: #8fa1b2;
+  --theme-content-color3: #667380;
+
+  --theme-highlight-green: hsl(72,100%,27%);
+  --theme-highlight-blue: hsl(208,56%,40%);
+  --theme-highlight-bluegrey: hsl(208,81%,21%);
+  --theme-highlight-purple: #5b5fff;
+  --theme-highlight-lightorange: #a18650;
+  --theme-highlight-orange: hsl(24,85%,39%);
+  --theme-highlight-red: #bf5656;
+  --theme-highlight-pink: #b82ee5;
+}

--- a/lib/chrome/theme.js
+++ b/lib/chrome/theme.js
@@ -40,6 +40,7 @@ Theme.registerFirebugTheme = function(options) {
 
   // List of styles to load.
   let sharedStyles = [
+    skinUrl + "firebug-style-variables.css",
     skinUrl + "common.css",
     skinUrl + "firebug-theme.css",
     skinUrl + "toolbox.css",


### PR DESCRIPTION
When you run jpm test it now reduces the console.log errors from 320+ to around 250. there are no more errors relating to "Property contained reference to invalid variable". This also indirectly resolves issue #278.