### PR TITLE
Issue #279. Changed the colour of black boxed source locations to be more readable.

### DIFF
--- a/chrome/skin/classic/shared/debugger.css
+++ b/chrome/skin/classic/shared/debugger.css
@@ -40,6 +40,14 @@
   cursor: pointer;
 }
 
+.theme-firebug #sources .black-boxed {
+  color: rgb(81, 81, 81);
+}
+
+#sources .selected .black-boxed {
+  color: rgb(0, 0, 0);
+}
+
 /******************************************************************************/
 /* Sources Panel Breakpoints */
 


### PR DESCRIPTION
1. Changed colour of black boxed source text to rgb(81,81,81)
2. Changed colour of selected black boxed source text to black (rgb(0,0,0))
3. Styles put into chrome/skin/classic/shared/debugger.css (the /* Sources Panel */ section)