### PR TITLE
Fixes Issue #30 - OS-X - Use arrow style for twisties

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,7 +1,7 @@
 content firebug             chrome/content/
 skin firebug classic/1.0    chrome/skin/classic/shared/
 
-skin firebug-os classic/1.0 chrome/skin/classic/win/
+skin firebug-os classic/1.0 chrome/skin/classic/shared/
 skin firebug-os classic/1.0 chrome/skin/classic/mac/ os=Darwin
 skin firebug-os classic/1.0 chrome/skin/classic/linux/ os=Linux
 

--- a/chrome/skin/classic/mac/twistyClosed.svg
+++ b/chrome/skin/classic/mac/twistyClosed.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- See license.txt for terms of usage -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="11"
+   height="11"
+   id="svg2">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1041.3622)"
+     id="layer1">
+    <path
+       d="m 9.7340317,5.4343104 -9.11896279,5.2648356 0,-10.52967117 z"
+       transform="matrix(0.87729276,0,0,0.90221241,0.96040447,1041.9593)"
+       id="path3000"
+       style="fill:#737373;fill-opacity:1;stroke:#737373;stroke-width:1.12401807;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/chrome/skin/classic/mac/twistyOpen.svg
+++ b/chrome/skin/classic/mac/twistyOpen.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- See license.txt for terms of usage -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="11"
+   height="11"
+   id="svg2">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1041.3622)"
+     id="layer1">
+    <path
+       d="m 9.7340317,5.4343104 -9.11896279,5.2648356 0,-10.52967117 z"
+       transform="matrix(0,0.87729276,-0.90221241,0,10.402902,1042.3226)"
+       id="path3000"
+       style="fill:#737373;fill-opacity:1;stroke:#737373;stroke-width:1.12401807;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/chrome/skin/classic/shared/debugger.css
+++ b/chrome/skin/classic/shared/debugger.css
@@ -33,7 +33,7 @@
 
 .theme-firebug #sources-pane .side-menu-widget-group-title label {
   padding-left: 17px;
-  background-image: url("chrome://firebug/skin/twistyOpen.svg");
+  background-image: url("chrome://firebug-os/skin/twistyOpen.svg");
   background-position: 0 calc(0.5em - 3px);
   background-size: 11px 11px;
   background-repeat: no-repeat;

--- a/chrome/skin/classic/shared/firebug-theme.css
+++ b/chrome/skin/classic/shared/firebug-theme.css
@@ -260,7 +260,7 @@ div.CodeMirror span.eval-text {
 
 .theme-twisty {
   cursor: pointer;
-  background-image: url("chrome://firebug/skin/twistyClosed.svg");
+  background-image: url("chrome://firebug-os/skin/twistyClosed.svg");
   background-position: 0 calc(0.5em - 3px);
   background-size: 11px 11px;
 }
@@ -270,7 +270,7 @@ div.CodeMirror span.eval-text {
 }
 
 .theme-twisty[open] {
-  background-image: url("chrome://firebug/skin/twistyOpen.svg");
+  background-image: url("chrome://firebug-os/skin/twistyOpen.svg");
 }
 
 .theme-twisty[invisible] {

--- a/chrome/skin/classic/shared/markup-view.css
+++ b/chrome/skin/classic/shared/markup-view.css
@@ -28,11 +28,11 @@
 .theme-firebug .theme-twisty {
   background-size: 11px 11px;
   background-position: 0 1px;
-  background-image: url("chrome://firebug/skin/twistyClosed.svg");
+  background-image: url("chrome://firebug-os/skin/twistyClosed.svg");
 }
 
 .theme-firebug .theme-twisty[open] {
-  background-image: url("chrome://firebug/skin/twistyOpen.svg");
+  background-image: url("chrome://firebug-os/skin/twistyOpen.svg");
   background-size: 11px 11px;
   background-position: 0 1px;
 }

--- a/chrome/skin/classic/shared/panel.css
+++ b/chrome/skin/classic/shared/panel.css
@@ -19,7 +19,7 @@
 .breakpointHeader > .twisty,
 .computedStyle.hasSelectors > .stylePropName,
 .cookieRow > .cookieNameCol > .cookieNameLabel {
-  background-image: url(chrome://firebug/skin/twistyClosed.svg);
+  background-image: url(chrome://firebug-os/skin/twistyClosed.svg);
   background-repeat: no-repeat;
   background-position: 2px calc(0.5em - 3px);
   min-height: 12px;
@@ -43,7 +43,7 @@
 .breakpointBlock.opened > .breakpointHeader > .twisty,
 .computedStyle.hasSelectors.opened > .stylePropName,
 .cookieRow.opened > .cookieNameCol > .cookieNameLabel {
-  background-image: url(chrome://firebug/skin/twistyOpen.svg);
+  background-image: url(chrome://firebug-os/skin/twistyOpen.svg);
   background-repeat: no-repeat;
   min-height: 12px;
 }

--- a/chrome/skin/classic/shared/xhr-spy.css
+++ b/chrome/skin/classic/shared/xhr-spy.css
@@ -29,7 +29,7 @@
 }
 
 .theme-firebug .xhrSpy .message-body {
-  background-image: url("chrome://firebug/skin/twistyClosed.svg");
+  background-image: url("chrome://firebug-os/skin/twistyClosed.svg");
   background-position: 0 calc(0.5em - 5px);
   padding-left: 15px;
   background-size: 11px 11px;
@@ -39,7 +39,7 @@
 }
 
 .theme-firebug .xhrSpy.opened .message-body {
-  background-image: url("chrome://firebug/skin/twistyOpen.svg");
+  background-image: url("chrome://firebug-os/skin/twistyOpen.svg");
 }
 
 .theme-firebug .xhrSpy .message-body .status {


### PR DESCRIPTION
The manifest file had to change because default skins firefox-os was pointing to classic/win which does not exist. The two Mac OS icons had to be created as they didn't exist. I took a direct copy of them from firebug 2. 

Could someone with Windows and Linux setup test it? For WIndows/Linux you should see a "+" or a "-" where with Mac OS you should see the twisties in all the various places they are normally seen.

Thanks @janodvarko for pointing me in the right direction with issue #30. It must of been the @link that wasn't working correctly. 