### PR TITLE
Fix panel registrar

### DIFF
--- a/lib/chrome/panel-registrar.js
+++ b/lib/chrome/panel-registrar.js
@@ -76,26 +76,30 @@ const PanelRegistrar =
 
   // Panel Registration API
 
-  registerPanel: function(panelId, PanelClass) {
-    if (gDevTools.getToolDefinition(panelId)) {
+  registerPanel: function(PanelClass) {
+    let { id } = PanelClass.prototype;
+
+    if (gDevTools.getToolDefinition(id)) {
       return;
     }
 
     const tool = new Tool({
-      name: panelId + "Tool",
+      name: id + "Tool",
       panels: {
         firebugPanel: PanelClass
       }
     });
   },
 
-  unregisterPanel: function(panelId) {
-    if (!gDevTools.getToolDefinition(panelId)) {
+  unregisterPanel: function(PanelClass) {
+    let { id } = PanelClass.prototype;
+
+    if (!gDevTools.getToolDefinition(id)) {
       return;
     }
 
     gDevTools.unregisterTool({
-      id: panelId
+      id: id
     });
   }
 };

--- a/lib/debug/actor-inspector/inspector-panel.js
+++ b/lib/debug/actor-inspector/inspector-panel.js
@@ -247,22 +247,22 @@ target.on("onRegisterPanels", registrar => {
 });
 
 target.on("onUnregisterPanels", registrar => {
-  updateRegistration(registrar);
+  registrar.unregisterPanel(InspectorPanel);
 });
 
 simplePrefs.on("env", prefName => {
   updateRegistration(PanelRegistrar);
-})
+});
 
 function updateRegistration(registrar) {
   let dev = (simplePrefs.prefs["env"] == "development");
   let theme = Theme.isFirebugActive();
 
   if (dev && theme) {
-    registrar.registerPanel(panelId, InspectorPanel);
+    registrar.registerPanel(InspectorPanel);
   }
   else {
-    registrar.unregisterPanel(panelId);
+    registrar.unregisterPanel(InspectorPanel);
   }
 }
 

--- a/lib/dom/dom-panel.js
+++ b/lib/dom/dom-panel.js
@@ -249,11 +249,11 @@ const DomPanel = Class(
  * is active.
  */
 target.on("onRegisterPanels", registrar => {
-  registrar.registerPanel(panelId, DomPanel);
+  registrar.registerPanel(DomPanel);
 });
 
 target.on("onUnregisterPanels", registrar => {
-  registrar.unregisterPanel(panelId);
+  registrar.unregisterPanel(DomPanel);
 });
 
 // Exports from this module


### PR DESCRIPTION
Devtool panels registered using the PanelRegistrar class (e.g. the RDP and DOM Panels) are not removed correctly
and are registered multiple times because the panelId is incorrect. 

This patch fix the two issues:
it uses PanelClass.prototype.id as the panelId to check devtool panels for existence (preventing multiple registration
of the same devtool panel) and on unregister (removing the panel correctly on add-on uninstall/disable/upgrade).

### How to test:
- enable the RDP panel (e.g. go set extensions.firebug@software.joehewitt.com.env to “development” in the about:config)
- disable and re-enable the Firebug.next add-on from the Addon Manager ( about:addons )

### Rationale
In the addon-sdk the Tool class register a devtool panel using ```PanelClass.prototype.id``` as its ids:
- https://github.com/mozilla/addon-sdk/blob/62deae2/lib/dev/toolbox.js#L44

This attribute is computed by the id getter in the Panel class:
- https://github.com/mozilla/addon-sdk/blob62deae2/lib/dev/panel.js#L106

and the id is actually computed (from the panel name or label):
- https://github.com/mozilla/addon-sdk/blob/62deae2/lib/dev/panel.js#L36

