### PR TITLE
RDP Panel: search filter on packets, actors and factories panels

### DIFF
--- a/data/actor-inspector/factories.js
+++ b/data/actor-inspector/factories.js
@@ -34,8 +34,14 @@ var FactoryTable = React.createClass({
   render: function() {
     var rows = [];
 
-    var factories = this.props;
+    var factories = this.props.factories;
     for (var i in factories) {
+      if (this.props.searchFilter &&
+          JSON.stringify(factories[i]).indexOf(this.props.searchFilter) < 0) {
+        // filter out packets which don't match the filter
+        continue;
+      }
+
       rows.push(FactoryRow(factories[i]));
     };
 
@@ -56,22 +62,30 @@ var FactoryTable = React.createClass({
  * TODO docs
  */
 var FactoryList = React.createClass({
+  getInitialState: function() {
+    return {
+      main: {factories: {}},
+      child: {factories: {}},
+      searchFilter: null
+    };
+  },
   render: function() {
     var mainGlobal = [];
-    var main = this.props[0];
-    var child = this.props[1];
+    var main = this.state.main;
+    var child = this.state.child;
+    var searchFilter = this.state.searchFilter;
 
     // xxxHonza: localization
     return (
       DIV({className: "poolContainer"},
         H4(null, "Main Process - Global Factories"),
-        FactoryTable(main.factories.global),
+        FactoryTable({ factories: main.factories.global, searchFilter: searchFilter }),
         H4(null, "Main Process - Tab Factories"),
-        FactoryTable(main.factories.tab),
+        FactoryTable({ factories: main.factories.tab, searchFilter: searchFilter }),
         H4(null, "Child Process - Global Factories"),
-        FactoryTable(child.factories.global),
+        FactoryTable({ factories: child.factories.global, searchFilter: searchFilter }),
         H4(null, "Child Process - Tab Factories"),
-        FactoryTable(child.factories.tab)
+        FactoryTable({ factories: child.factories.tab, searchFilter: searchFilter })
       )
     );
   }
@@ -80,8 +94,8 @@ var FactoryList = React.createClass({
 var factoryList = React.createFactory(FactoryList);
 
 var Factories = {
-  render: function(packet, parentNode) {
-    React.render(factoryList(packet), parentNode);
+  render: function(parentNode) {
+    return React.render(factoryList(), parentNode);
   }
 }
 

--- a/data/actor-inspector/inspector.js
+++ b/data/actor-inspector/inspector.js
@@ -19,12 +19,6 @@ require("reps/number");
 require("reps/array");
 require("reps/object");
 
-// Initialization
-window.addEventListener("refresh", onRefresh);
-window.addEventListener("clear", onClear);
-window.addEventListener("send-packet", onSendPacket);
-window.addEventListener("receive-packet", onReceivePacket);
-
 var packets = [];
 
 // Initial panel rendering
@@ -32,17 +26,36 @@ renderTabbedBox();
 
 // Render packet list.
 var packetList = React.render(PacketList(packets),
-  $("#tabPacketsPane").get(0));
+                              document.querySelector("#tabPacketsPane"));
+var globalActorsPane = Pools.render(document.querySelector("#globalActorsPane"));
+var tabActorsPane = Pools.render(document.querySelector("#tabActorsPane"));
+var actorFactoriesPane = Factories.render(document.querySelector("#actorFactoriesPane"));
+
+// Initialization
+window.addEventListener("refresh", onRefresh);
+window.addEventListener("clear", onClear);
+window.addEventListener("send-packet", onSendPacket);
+window.addEventListener("receive-packet", onReceivePacket);
+window.addEventListener("search", onSearch);
 
 /**
  * Renders content of the Inspector panel.
  */
 function onRefresh(event) {
   var packet = JSON.parse(event.data);
-  refreshActors(packet[0], "globalActorsPane");
-  refreshActors(packet[1], "tabActorsPane");
-  refreshPackets("tabPacketsPane");
-  refreshFactories(packet, "actorFactoriesPane");
+  refreshActors(packet[0], globalActorsPane);
+  refreshActors(packet[1], tabActorsPane);
+  refreshFactories(packet[0], packet[1]);
+  refreshPackets();
+}
+
+function onSearch(event) {
+  var value = JSON.parse(event.data);
+
+  packetList.setState({ searchFilter: value });
+  globalActorsPane.setState({ searchFilter: value });
+  tabActorsPane.setState({ searchFilter: value });
+  actorFactoriesPane.setState({ searchFilter: value });
 }
 
 function onClear() {
@@ -50,20 +63,15 @@ function onClear() {
   refreshPackets();
 }
 
-function refreshActors(data, parentNodeId) {
-  var actorsPane = document.getElementById(parentNodeId);
+function refreshActors(data, poolPane) {
   var pools = [data.actorPool];
   pools.push.apply(pools, data.extraPools.slice());
 
-  // xxxHonza: use setState to refresh.
-  Pools.render(pools, actorsPane);
+  poolPane.setState({pools: pools});
 }
 
-function refreshFactories(packet, parentNodeId) {
-  var pane = document.getElementById(parentNodeId);
-
-  // xxxHonza: use setState to refresh.
-  Factories.render(packet, pane);
+function refreshFactories(main, child) {
+  actorFactoriesPane.setState({main: main, child: child});
 }
 
 /**

--- a/data/actor-inspector/packet-list.js
+++ b/data/actor-inspector/packet-list.js
@@ -24,6 +24,11 @@ var PacketList = React.createClass({
 
     var packets = this.state.data;
     for (var i in packets) {
+      if (this.state.searchFilter &&
+         JSON.stringify(packets[i]).indexOf(this.state.searchFilter) < 0) {
+        // filter out packets which don't match the filter
+        continue;
+      }
       output.push(Packet(packets[i]));
     };
 

--- a/data/actor-inspector/pools.js
+++ b/data/actor-inspector/pools.js
@@ -38,6 +38,11 @@ var PoolTable = React.createClass({
     // Iterate array of actors.
     var actors = this.props.pool;
     for (var i in actors) {
+      if (this.props.searchFilter &&
+          JSON.stringify(actors[i]).indexOf(this.props.searchFilter) < 0) {
+        // filter out packets which don't match the filter
+        continue;
+      }
       rows.push(PoolRow(actors[i]));
     };
 
@@ -71,11 +76,16 @@ var PoolTable = React.createClass({
  * TODO docs
  */
 var PoolList = React.createClass({
+  getInitialState: function() {
+    return {
+      pools: []
+    };
+  },
   render: function() {
     var pools = [];
 
-    for (var i in this.props) {
-      var poolData = this.props[i];
+    for (var i in this.state.pools) {
+      var poolData = this.state.pools[i];
       var pool = poolData.pool;
       var poolId = poolData.id;
 
@@ -91,7 +101,8 @@ var PoolList = React.createClass({
       pools.push(PoolTable({
         pool: pool,
         actorClass: actorClass,
-        id: poolId
+        id: poolId,
+        searchFilter: this.state.searchFilter
       }));
     };
 
@@ -106,8 +117,8 @@ var PoolList = React.createClass({
 var poolList = React.createFactory(PoolList);
 
 var Pools = {
-  render: function(data, parentNode) {
-    React.render(poolList(data), parentNode);
+  render: function(parentNode) {
+    return React.render(poolList(), parentNode);
   }
 }
 

--- a/lib/debug/actor-inspector/inspector-panel.js
+++ b/lib/debug/actor-inspector/inspector-panel.js
@@ -199,6 +199,10 @@ const InspectorPanel = Class(
     this.panelFrame.contentWindow.location.reload();
   },
 
+  onSearch: function(value) {
+    this.postCommand("search", value);
+  },
+
   onRefresh: function() {
     Trace.sysout("inspectorPanel.onRefresh;");
 


### PR DESCRIPTION
- render React components once and propagate state changes using ```setState``` method
- enable search filter on packet list, actors pools and actors factories panels 
  (currently it simply searches the searchFilter string in the data object converted into a string using ```JSON.stringify```)

- [ ] fix fails on travis (https://travis-ci.org/firebug/firebug.next/builds/51371235)

Prototype preview screencast:

![firebugnextrdppanelsearchfilter](https://cloud.githubusercontent.com/assets/11484/6213821/f8cbcc5c-b5f3-11e4-9f01-3b547ab41b50.gif)