### PR TITLE
Fix test start button failure

### DIFF
--- a/lib/chrome/chrome.js
+++ b/lib/chrome/chrome.js
@@ -74,6 +74,8 @@ const Chrome = Class(
       return;
     }
 
+    this.browserDoc = this.toolbox.doc.defaultView.top.document;
+
     this.ready = true;
 
     Trace.sysout("chrome.onReady;");
@@ -146,7 +148,7 @@ const Chrome = Class(
   // Browser
 
   getBrowserDoc: function() {
-    return this.toolbox.doc.defaultView.top.document;
+    return this.browserDoc;
   },
 
   // Context

--- a/lib/firebug.js
+++ b/lib/firebug.js
@@ -311,10 +311,6 @@ var Firebug = extend(EventTarget.prototype,
     }
 
     this.target.emit("onToolboxDestroy", arguments);
-
-    // A toolbox object has been destroyed, so destroy even the corresponding
-    // {@Chrome} object.
-    chrome.destroy();
   },
 
   /**
@@ -330,6 +326,10 @@ var Firebug = extend(EventTarget.prototype,
       Trace.sysout("firebug.onToolboxClosed; ERROR unknown target!", target);
       return;
     }
+
+    // A toolbox object has been destroyed, so destroy even the corresponding
+    // {@Chrome} object.
+    chrome.destroy();
 
     chrome.close();
 

--- a/test/test-start-button.js
+++ b/test/test-start-button.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { StartButton } = require("../lib/chrome/start-button.js");
-const { getToolboxWhenReady, closeToolbox } = require("./toolbox.js");
+const { getToolboxWhenReady, closeToolbox, waitUntil } = require("./toolbox.js");
 const { closeTab } = require("./window.js");
 
 /**
@@ -16,14 +16,21 @@ exports["test Start Button"] = function(assert, done) {
     let browserDoc = chrome.getBrowserDoc();
 
     let button = StartButton.getButton(browserDoc);
-    let active = button.getAttribute("active");
-    assert.equal(active, "true", "The start button must be active now");
 
-    closeToolbox(tab).then(() => {
+    waitUntil(() => button.getAttribute("active") === "true", 5000).then(() => {
       let active = button.getAttribute("active");
-      assert.ok(!active, "The start button must be deactivated now");
 
-      closeTab(tab);
+      assert.equal(active, "true", "The start button must be active now");
+
+      closeToolbox(tab).then(() => {
+        let active = button.getAttribute("active");
+        assert.ok(!active, "The start button must be deactivated now");
+
+        closeTab(tab);
+        done();
+      });
+    }, (e) => {
+      assert.fail("Test timed out waiting the start button to become active");
       done();
     });
   });


### PR DESCRIPTION
The test-start-button test case seems to fail for the following 3 reasons:

- the Start button is not already active when the toolbox-ready events is emitted (the added ```waitUntil``` test helper waits the start button to become active and fails if it doesn't in a defined time slice)
- the Start button wasn't disabled when the toolbox is destroyed, because when the ```destroyContext``` events is emitted, the toolbox panel is not yet destroyed (this change move ```chrome.destroy()```, which emits the ```destroyContext``` event, in the ```onToolboxClosed``` handler, when the toolbox is already fully destroyed)