### PR TITLE
Fix ReactJS 'legacyfactory' and 'missing keys' warnings

### DIFF
--- a/data/actor-inspector/factories.js
+++ b/data/actor-inspector/factories.js
@@ -13,7 +13,8 @@ const { TR, TD, SPAN, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 /**
  * TODO docs
  */
-var FactoryRow = React.createClass({
+var FactoryRow = React.createFactory(React.createClass({
+  displayName: "FactoryRow",
   render: function() {
     var factory = this.props;
     return (
@@ -24,13 +25,14 @@ var FactoryRow = React.createClass({
       )
     );
   }
-});
+}));
 
 /**
  * TODO docs
  * xxxHonza: localization
  */
-var FactoryTable = React.createClass({
+var FactoryTable = React.createFactory(React.createClass({
+  displayName: "FactoryTable",
   render: function() {
     var rows = [];
 
@@ -42,6 +44,7 @@ var FactoryTable = React.createClass({
         continue;
       }
 
+      factories[i].key = factories[i].prefix + factories[i].name;
       rows.push(FactoryRow(factories[i]));
     };
 
@@ -56,12 +59,13 @@ var FactoryTable = React.createClass({
       )
     );
   }
-});
+}));
 
 /**
  * TODO docs
  */
-var FactoryList = React.createClass({
+var FactoryList = React.createFactory(React.createClass({
+  displayName: "FactoryList",
   getInitialState: function() {
     return {
       main: {factories: {}},
@@ -89,13 +93,11 @@ var FactoryList = React.createClass({
       )
     );
   }
-});
-
-var factoryList = React.createFactory(FactoryList);
+}));
 
 var Factories = {
   render: function(parentNode) {
-    return React.render(factoryList(), parentNode);
+    return React.render(FactoryList(), parentNode);
   }
 }
 

--- a/data/actor-inspector/packet-list.js
+++ b/data/actor-inspector/packet-list.js
@@ -15,6 +15,7 @@ const { DIV } = Reps.DOM;
  * inside the panel content.
  */
 var PacketList = React.createClass({
+  displayName: "PacketList",
   getInitialState: function() {
     return { data: [] };
   },
@@ -29,6 +30,7 @@ var PacketList = React.createClass({
         // filter out packets which don't match the filter
         continue;
       }
+      packets[i].key = i;
       output.push(Packet(packets[i]));
     };
 

--- a/data/actor-inspector/packet.js
+++ b/data/actor-inspector/packet.js
@@ -17,6 +17,7 @@ const { DIV, SPAN, BR, IMG } = Reps.DOM;
  * TODO docs
  */
 var Packet = React.createClass({
+  displayName: "Packet",
   render: function() {
     var packet = this.props.packet;
     var type = packet.type ? "\"" + packet.type + "\"" : "";

--- a/data/actor-inspector/pools.js
+++ b/data/actor-inspector/pools.js
@@ -12,7 +12,8 @@ const { TR, TD, SPAN, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 /**
  * TODO docs
  */
-var PoolRow = React.createClass({
+var PoolRow = React.createFactory(React.createClass({
+  displayName: "PoolRow",
   render: function() {
     var actor = this.props;
     return (
@@ -25,13 +26,14 @@ var PoolRow = React.createClass({
       )
     );
   }
-});
+}));
 
 /**
  * TODO docs
  * xxxHonza: localization
  */
-var PoolTable = React.createClass({
+var PoolTable = React.createFactory(React.createClass({
+  displayName: "PoolTable",
   render: function() {
     var rows = [];
 
@@ -43,6 +45,7 @@ var PoolTable = React.createClass({
         // filter out packets which don't match the filter
         continue;
       }
+      actors[i].key = actors[i].actorID;
       rows.push(PoolRow(actors[i]));
     };
 
@@ -70,12 +73,13 @@ var PoolTable = React.createClass({
       )
     );
   }
-});
+}));
 
 /**
  * TODO docs
  */
-var PoolList = React.createClass({
+var PoolList = React.createFactory(React.createClass({
+  displayName: "PoolList",
   getInitialState: function() {
     return {
       pools: []
@@ -102,6 +106,7 @@ var PoolList = React.createClass({
         pool: pool,
         actorClass: actorClass,
         id: poolId,
+        key: i,
         searchFilter: this.state.searchFilter
       }));
     };
@@ -112,13 +117,11 @@ var PoolList = React.createClass({
       )
     );
   }
-});
-
-var poolList = React.createFactory(PoolList);
+}));
 
 var Pools = {
   render: function(parentNode) {
-    return React.render(poolList(), parentNode);
+    return React.render(PoolList(), parentNode);
   }
 }
 

--- a/data/actor-inspector/tabs.js
+++ b/data/actor-inspector/tabs.js
@@ -24,6 +24,7 @@ function handleSelect(selectedKey) {
 
 // xxxHonza: TODO: localization
 var TabbedBox = React.createClass({
+  displayName: "TabbedBox",
   render: function() {
     return (
       TabbedArea({activeKey: key, onSelect: handleSelect},

--- a/data/reps/array.js
+++ b/data/reps/array.js
@@ -19,6 +19,7 @@ const { SPAN, A } = Reps.DOM;
 var ItemRep = React.createFactory(React.createClass(
 /** @lends ItemRep */
 {
+  displayName: "ItemRep",
   render: function(){
     var object = this.props.object;
     var delim = this.props.delim;
@@ -38,6 +39,7 @@ var ItemRep = React.createFactory(React.createClass(
 var ArrayRep = React.createClass(
 /** @lends ArrayRep */
 {
+  displayName: "ArrayRep",
   render: function() {
     var mode = this.props.mode || "short";
     var object = this.props.object;
@@ -85,18 +87,20 @@ var ArrayRep = React.createClass(
         //}
 
         items.push(ItemRep({
+          key: i,
           object: value,
           delim: delim
         }));
       }
       catch (exc) {
-        items.push(ItemRep({object: exc, delim: delim}));
+        items.push(ItemRep({object: exc, delim: delim, key: i}));
       }
     }
 
     if (array.length > max + 1) {
       items.pop();
       items.push(Caption({
+        key: "more",
         object: Locale.$STR("reps.more"),
       }));
     }

--- a/data/reps/caption.js
+++ b/data/reps/caption.js
@@ -13,10 +13,11 @@ const { SPAN } = Reps.DOM;
  * @template TODO docs
  */
 const Caption = React.createClass({
+  displayName: "Caption",
   render: function() {
     return (
-      SPAN({"class": "caption"}, this.props.object)
-    )
+      SPAN({"className": "caption"}, this.props.object)
+    );
   },
 });
 

--- a/data/reps/number.js
+++ b/data/reps/number.js
@@ -13,6 +13,7 @@ const { ObjectBox } = require("reps/object-box");
  * @template TODO docs
  */
 const Number = React.createClass({
+  displayName: "Number",
   render: function() {
     var value = this.props.object;
     if (this.props.mode == "tiny") {

--- a/data/reps/object-box.js
+++ b/data/reps/object-box.js
@@ -13,6 +13,7 @@ const { SPAN } = Reps.DOM;
  * @template TODO docs
  */
 const ObjectBox = React.createClass({
+  displayName: "ObjectBox",
   render: function() {
     var className = this.props.className;
     var boxClassName = className ? " objectBox-" + className : "";

--- a/data/reps/object-link.js
+++ b/data/reps/object-link.js
@@ -13,6 +13,7 @@ const { A } = Reps.DOM;
  * @template TODO docs
  */
 const ObjectLink = React.createClass({
+  displayName: "ObjectLink",
   render: function() {
     var className = this.props.className;
     var objectClassName = className ? " objectLink-" + className : "";

--- a/data/reps/object.js
+++ b/data/reps/object.js
@@ -18,6 +18,7 @@ const { SPAN } = Reps.DOM;
  * @template TODO docs
  */
 const Obj = React.createClass({
+  displayName: "Obj",
   render: function() {
     var object = this.props.object;
     var props = this.shortPropIterator(object);
@@ -84,6 +85,7 @@ const Obj = React.createClass({
     if (props.length > max) {
       props.pop();
       props.push(Caption({
+        key: "more",
         object: Locale.$STR("reps.more"),
       }));
     }
@@ -133,6 +135,7 @@ const Obj = React.createClass({
           }
 
           props.push(PropRep({
+            key: name,
             mode: "short",
             name: name,
             object: value,
@@ -157,23 +160,24 @@ const Obj = React.createClass({
 /**
  * @rep
  */
-var PropRep = React.createClass(
+var PropRep = React.createFactory(React.createClass(
 /** @lends PropRep */
 {
+  displayName: "PropRep",
   render: function(){
     var object = this.props.object;
     var mode = this.props.mode;
     var TAG = Reps.getRep(object);
     return (
       SPAN({},
-        SPAN({"class": "nodeName"}, this.props.name),
-        SPAN({"class": "objectEqual", role: "presentation"}, this.props.equal),
+        SPAN({"className": "nodeName"}, this.props.name),
+        SPAN({"className": "objectEqual", role: "presentation"}, this.props.equal),
         TAG({object: object, mode: mode}),
-        SPAN({"class": "objectComma", role: "presentation"}, this.props.delim)
+        SPAN({"className": "objectComma", role: "presentation"}, this.props.delim)
       )
-    )
+    );
   }
-});
+}));
 
 // Registration
 

--- a/data/reps/string.js
+++ b/data/reps/string.js
@@ -13,6 +13,7 @@ const { ObjectBox } = require("reps/object-box");
  * @template TODO docs
  */
 const String = React.createClass({
+  displayName: "String",
   render: function() {
     var text = this.props.object;
     if (this.props.mode == "short") {

--- a/data/reps/tree-view.js
+++ b/data/reps/tree-view.js
@@ -11,6 +11,7 @@ const { TR, TD, SPAN, TABLE, TBODY } = Reps.DOM;
  * @template TODO docs
  */
 var TreeView = React.createFactory(React.createClass({
+  displayName: "TreeView",
   getInitialState: function() {
     return { data: {}, uid: 0 };
   },
@@ -138,6 +139,7 @@ var TreeView = React.createFactory(React.createClass({
  * @template TODO docs
  */
 var TreeRow = React.createFactory(React.createClass({
+  displayName: "TreeRow",
   getInitialState: function() {
     return { data: {} };
   },

--- a/data/reps/undefined.js
+++ b/data/reps/undefined.js
@@ -13,6 +13,7 @@ const { ObjectBox } = require("reps/object-box");
  * @template TODO docs
  */
 const Undefined = React.createClass({
+  displayName: "UndefinedRep",
   render: function() {
     return (
       ObjectBox({className: "undefined"},


### PR DESCRIPTION
This pull request applies the following tweaks to the React components to fix a bunch of warnings:

- add ```displayName``` property to all the React components (used by React to produce better warnings)
- apply ```React.createFactory``` where it was not yet applied (fix 'legacyfactory' React warning)
- add ```key``` property on any array of React components (fix 'missing keys' React warning)
- change ```class``` in ```className``` (fix a couple of 'class should be className' React warnings)