### PR TITLE
Added twisties for Linux distro. Fixes #350

### DIFF
--- a/chrome/skin/classic/linux/twistyClosed.svg
+++ b/chrome/skin/classic/linux/twistyClosed.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- See license.txt for terms of usage -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="11"
+   height="11"
+   id="svg2">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3792">
+      <stop
+         id="stop3795"
+         style="stop-color:#c3baaa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3797"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient3799"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,-0.11538478,1.8846152)" />
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient2992"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,-0.11538478,1.8846152)" />
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient2996"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,0.88461522,0.8846152)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="8"
+     height="8"
+     rx="1"
+     ry="1"
+     x="1.5"
+     y="1.5"
+     id="rect3022"
+     style="fill:url(#linearGradient2996);fill-opacity:1;stroke:#7898b5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+  <path
+     d="M 5,3 5,5 3,5 3,6 5,6 5,8 6,8 6,6 8,6 8,5 6,5 6,3 5,3 z"
+     id="rect3801"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/chrome/skin/classic/linux/twistyOpen.svg
+++ b/chrome/skin/classic/linux/twistyOpen.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- See license.txt for terms of usage -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="11"
+   height="11"
+   id="svg2">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3792">
+      <stop
+         id="stop3795"
+         style="stop-color:#c3baaa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3797"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient3799"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,-0.11538478,1.8846152)" />
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient2992"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,-0.11538478,1.8846152)" />
+    <linearGradient
+       x1="6.0530181"
+       y1="7.092885"
+       x2="2.8882971"
+       y2="1.7999334"
+       id="linearGradient2996"
+       xlink:href="#linearGradient3792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0256411,0,0,1.0256411,0.88461522,0.8846152)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="8"
+     height="8"
+     rx="1"
+     ry="1"
+     x="1.5"
+     y="1.5"
+     id="rect3022"
+     style="fill:url(#linearGradient2996);fill-opacity:1;stroke:#7898b5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+  <rect
+     width="5"
+     height="1"
+     x="3"
+     y="5"
+     id="rect3801"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
Twisties were not showing for linux distro so I have now copied "+/-" svg into the linux skin folder. This issue was caused by #30 (OSX twisty not displaying).