### PR TITLE
Fix mozilla-download options changed in travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 - npm install jpm -g
 - npm install mozilla-download -g
 - cd ..
-- mozilla-download --branch fx-team -c tinderbox firefox --host ftp.mozilla.org
+- mozilla-download --branch fx-team --product firefox $TRAVIS_BUILD_DIR/../
 - cd $TRAVIS_BUILD_DIR
 
 script:


### PR DESCRIPTION
This pr tweaks the .travis-ci.yml to fix failed builds related to changes in the mozilla-download command line options syntax.

Build passed: https://travis-ci.org/rpl/firebug.next/builds/57773104