### PR TITLE
Issue434: Move filter field in the Network panel to the top

### DIFF
--- a/chrome/skin/classic/shared/netmonitor.css
+++ b/chrome/skin/classic/shared/netmonitor.css
@@ -17,7 +17,7 @@ be toggle-side-panels button at the end at some point */
 /* Filter field */
 
 .theme-firebug .devtools-searchinput {
-  background-image: url(chrome://firebug/skin/filter.svg);
+  display: none;
 }
 
 /******************************************************************************/

--- a/lib/chrome/base-overlay.js
+++ b/lib/chrome/base-overlay.js
@@ -60,6 +60,74 @@ const BaseOverlay = Class(
     }
   },
 
+  setupSideOverlays: function() {
+    if (!this.sidebar) {
+      return;
+    }
+
+    let overlays = this.getSideOverlays();
+    if (!overlays) {
+      return;
+    }
+
+    for (let overlay of overlays) {
+      let overlayId = overlay.prototype.overlayId;
+      if (!overlayId) {
+        TraceError.sysout("baseOverlay.setupSideOverlays; ERROR " +
+          "no overlay ID!");
+        continue;
+      }
+
+      let panelFrame = this.getSidePanelFrame(overlayId);
+      if (!panelFrame) {
+        TraceError.sysout("baseOverlay.setupSideOverlays; ERROR " +
+          "no panel frame");
+        continue;
+      }
+
+      // Create instance of an overlay
+      let instance = new overlay({
+        owner: this,
+        panelFrame: panelFrame,
+        toolbox: this.toolbox,
+        id: overlayId
+      });
+
+      this.sideOverlays.set(overlayId, instance);
+
+      instance.onBuild({toolbox: this.toolbox});
+
+      if (Theme.isFirebugActive()) {
+        instance.applyTheme(panelFrame.contentWindow);
+      }
+
+      Win.loaded(panelFrame.contentWindow).then(doc => {
+        instance.onReady({toolbox: this.toolbox});
+      });
+    }
+  },
+
+  search: function (nativeSearchBoxSelector, value) {
+    let doc = this.getPanelDocument();
+    let win = this.getPanelWindow();
+
+    // Inject the searched pattern to the native search box.
+    // xxxHonza: The search box UI will be built-in at some point
+    // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1026479
+    // As soon as the bug is fixed this code will change TESTME
+    let nativeSearchBox = doc.querySelector(nativeSearchBoxSelector);
+    nativeSearchBox.value = value;
+
+    // Trigger the "command" event for the native search box
+    // to apply the filter.
+    let event = doc.createEvent("xulcommandevent");
+    event.initCommandEvent("command", true, true, win, 0, false, false, false,
+        false, null);
+    nativeSearchBox.dispatchEvent(event);
+  },
+
+  // Framework events
+
   /**
    * Executed by the framework when panel's frame is loaded.
    */
@@ -119,52 +187,26 @@ const BaseOverlay = Class(
     }
   },
 
-  setupSideOverlays: function() {
-    if (!this.sidebar) {
-      return;
-    }
+  onShow: function() {
+    BasePanel.prototype.onShow.apply(this, arguments);
 
-    let overlays = this.getSideOverlays();
-    if (!overlays) {
-      return;
-    }
-
-    for (let overlay of overlays) {
-      let overlayId = overlay.prototype.overlayId;
-      if (!overlayId) {
-        TraceError.sysout("baseOverlay.setupSideOverlays; ERROR " +
-          "no overlay ID!");
-        continue;
-      }
-
-      let panelFrame = this.getSidePanelFrame(overlayId);
-      if (!panelFrame) {
-        TraceError.sysout("baseOverlay.setupSideOverlays; ERROR " +
-          "no panel frame");
-        continue;
-      }
-
-      // Create instance of an overlay
-      let instance = new overlay({
-        owner: this,
-        panelFrame: panelFrame,
-        toolbox: this.toolbox,
-        id: overlayId
-      });
-
-      this.sideOverlays.set(overlayId, instance);
-
-      instance.onBuild({toolbox: this.toolbox});
-
-      if (Theme.isFirebugActive()) {
-        instance.applyTheme(panelFrame.contentWindow);
-      }
-
-      Win.loaded(panelFrame.contentWindow).then(doc => {
-        instance.onReady({toolbox: this.toolbox});
-      });
+    if (this.searchable && Theme.isFirebugActive()) {
+      this.updateSearchBox(true);
     }
   },
+
+  onHide: function() {
+    BasePanel.prototype.onHide.apply(this, arguments);
+
+    // Unapply search-box customization when the Inspector panel
+    // is hidden (unselected). The search box is shared among
+    // panels and other customization can apply.
+    if (this.searchable) {
+      this.updateSearchBox(false);
+    }
+  },
+
+  // getters
 
   getSideOverlays: function() {
     return [];

--- a/lib/chrome/base-overlay.js
+++ b/lib/chrome/base-overlay.js
@@ -93,6 +93,30 @@ const BaseOverlay = Class(
 
     this.setupSidePanels();
     this.setupSideOverlays();
+
+    if (this.searchable && Theme.isFirebugActive()) {
+      this.updateSearchBox(true);
+    }
+  },
+
+  onApplyTheme: function (win, oldTheme) {
+    BasePanel.prototype.onApplyTheme.apply(this, arguments);
+
+    Trace.sysout("baseOverlay.onApplyTheme;");
+
+    if (this.searchable) {
+      Win.loaded(win).then(() => this.updateSearchBox(true));
+    }
+  },
+
+  onUnapplyTheme: function (win, newTheme) {
+    BasePanel.prototype.onUnapplyTheme.apply(this, arguments);
+
+    Trace.sysout("baseOverlay.onUnapplyTheme;");
+
+    if (this.searchable) {
+      Win.loaded(win).then(() => this.updateSearchBox(false));
+    }
   },
 
   setupSideOverlays: function() {

--- a/lib/chrome/search-box.js
+++ b/lib/chrome/search-box.js
@@ -43,7 +43,7 @@ const SearchBox = Class(
 
     this.chrome = options.chrome;
 
-    this.onChange = this.onChange.bind(this);
+    this.search = this.search.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
 
     this.onPanelSelected = this.onPanelSelected.bind(this);
@@ -119,8 +119,8 @@ const SearchBox = Class(
       });
 
       let inputBox = this.getInputBox();
-      inputBox.addEventListener("command", this.onChange, false);
-      inputBox.addEventListener("input", this.onChange, false);
+      inputBox.addEventListener("command", this.search, false);
+      inputBox.addEventListener("input", this.search, false);
       inputBox.addEventListener("keypress", this.onKeyPress, false);
 
     }).then(null, TraceError.sysout);
@@ -175,11 +175,6 @@ const SearchBox = Class(
       else
         this.searchNext();
     }
-  },
-
-  onChange: function(event) {
-    clearTimeout(this.searchTimeout);
-    this.searchTimeout = setTimeout(this.search.bind(this), SEARCH_DELAY);
   },
 
   search: function() {

--- a/lib/console/console-overlay.js
+++ b/lib/console/console-overlay.js
@@ -626,14 +626,7 @@ const ConsoleOverlay = Class(
   },
 
   onSearch: function(value) {
-    let doc = this.getPanelDocument();
-
-    // xxxHonza: The search box UI will be built-in at some point
-    // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1026479
-    // As soon as the bug is fixed this code will change TESTME
-    let hudSearchBox = doc.querySelector(".hud-filter-box");
-    hudSearchBox.value = value;
-    this.panel.hud.ui.adjustVisibilityOnSearchStringChange();
+    this.search(".hud-filter-box", value);
   },
 
   onShow: function() {

--- a/lib/console/console-overlay.js
+++ b/lib/console/console-overlay.js
@@ -216,10 +216,6 @@ const ConsoleOverlay = Class(
 
     this.updateSideSplitterTheme();
 
-    if (Theme.isFirebugActive()) {
-      this.updateSearchBox(true);
-    }
-
     let win = this.getPanelWindow();
     let controller = new CommandController(this.chrome);
     win.controllers.insertControllerAt(0, controller);
@@ -487,6 +483,8 @@ const ConsoleOverlay = Class(
   },
 
   onApplyTheme: function(iframeWin, oldTheme) {
+    BaseOverlay.prototype.onApplyTheme.apply(this, arguments);
+
     Trace.sysout("consoleOverlay.onApplyTheme;", iframeWin);
 
     let doc = iframeWin.document;
@@ -502,7 +500,6 @@ const ConsoleOverlay = Class(
     Win.loaded(iframeWin).then(doc => {
       this.updateSideSplitterTheme();
       this.updatePersistButton(true);
-      this.updateSearchBox(true);
 
       this.toggleSideBar = new ToggleSideBarButton({
         panel: this,
@@ -522,6 +519,8 @@ const ConsoleOverlay = Class(
   },
 
   onUnapplyTheme: function(iframeWin, newTheme) {
+    BaseOverlay.prototype.onUnapplyTheme.apply(this, arguments);
+
     Trace.sysout("consoleOverlay.onUnapplyTheme;", iframeWin);
 
     let doc = iframeWin.document;
@@ -532,7 +531,6 @@ const ConsoleOverlay = Class(
     Win.loaded(iframeWin).then(doc => {
       this.updateSideSplitterTheme();
       this.updatePersistButton(false);
-      this.updateSearchBox(false);
     });
 
     this.toggleSideBar.destroy();

--- a/lib/debugger/debugger-overlay.js
+++ b/lib/debugger/debugger-overlay.js
@@ -44,8 +44,8 @@ const DebuggerOverlay = Class(
   },
 
   destroy: function() {
-    if (this.search) {
-      this.search.destroy();
+    if (this.searchHook) {
+      this.searchHook.destroy();
     }
   },
 
@@ -67,6 +67,8 @@ const DebuggerOverlay = Class(
   // Theme
 
   onApplyTheme: function(iframeWin, oldTheme) {
+    BaseOverlay.prototype.onApplyTheme.apply(this, arguments);
+
     Trace.sysout("debuggerOverlay.onApplyTheme; old theme: " +
       oldTheme, iframeWin);
 
@@ -110,6 +112,8 @@ const DebuggerOverlay = Class(
   },
 
   onUnapplyTheme: function(iframeWin, newTheme) {
+    BaseOverlay.prototype.onUnapplyTheme.apply(this, arguments);
+
     Trace.sysout("debuggerOverlay.onUnapplyTheme; new theme: " +
       newTheme, iframeWin);
 
@@ -172,7 +176,7 @@ const DebuggerOverlay = Class(
 
     Win.loaded(this.toolbox.doc.defaultView).then(() => {
       if (apply) {
-        if (!this.search) {
+        if (!this.searchHook) {
           let doc = this.getPanelDocument();
           // Copy search box value from the original search box.
           let searchInput = doc.querySelector(".devtools-searchinput");
@@ -180,25 +184,19 @@ const DebuggerOverlay = Class(
             "FirebugToolboxOverlay");
 
           overlay.searchBox.setValue(searchInput.value);
-          this.search = new DebuggerSearch({overlay: this});
+          this.searchHook = new DebuggerSearch({overlay: this});
         }
       } else {
-        if (this.search) {
-          this.search.destroy();
-          this.search = null;
+        if (this.searchHook) {
+          this.searchHook.destroy();
+          this.searchHook = null;
         }
       }
     });
   },
 
   onSearch: function(value) {
-    let doc = this.getPanelDocument();
-
-    // xxxHonza: The search box UI will be built-in at some point
-    // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1026479
-    // As soon as the bug is fixed this code will change TESTME
-    let searchInput = doc.querySelector(".devtools-searchinput");
-    searchInput.value = value;
+    this.search(".devtools-searchinput", value);
   },
 
   // Options

--- a/lib/debugger/debugger-overlay.js
+++ b/lib/debugger/debugger-overlay.js
@@ -40,7 +40,6 @@ const DebuggerOverlay = Class(
 
     if (Theme.isFirebugActive()) {
       this.updatePrettyPrintButton(true);
-      this.updateSearchBox(true);
     }
   },
 
@@ -106,7 +105,6 @@ const DebuggerOverlay = Class(
       sidebar.tabs.appendChild(tab);
       sidebar.tabpanels.appendChild(panel);
 
-      this.updateSearchBox(true);
       this.updatePrettyPrintButton(true);
     });
   },
@@ -137,7 +135,6 @@ const DebuggerOverlay = Class(
       sidebar.tabs.appendChild(tab);
       sidebar.tabpanels.appendChild(panel);
 
-      this.updateSearchBox(false);
       this.updatePrettyPrintButton(false);
     });
   },

--- a/lib/inspector/inspector-overlay.js
+++ b/lib/inspector/inspector-overlay.js
@@ -70,10 +70,6 @@ const InspectorOverlay = Class(
     BaseOverlay.prototype.onReady.apply(this, arguments);
 
     Trace.sysout("inspectorOverlay.onReady;", options);
-
-    if (Theme.isFirebugActive()) {
-      this.updateSearchBox(true);
-    }
   },
 
   destroy: function() {
@@ -104,6 +100,8 @@ const InspectorOverlay = Class(
   // Events
 
   onApplyTheme: function(iframeWin, oldTheme) {
+    BaseOverlay.prototype.onApplyTheme.apply(this, arguments);
+
     Trace.sysout("inspectorOverlay.onApplyTheme; " + iframeWin.inspector,
       iframeWin);
 
@@ -124,14 +122,16 @@ const InspectorOverlay = Class(
         panel: this,
         toolbar: doc.getElementById("inspector-toolbar"),
       });
-
-      this.updateSearchBox(true);
     });
 
     this.setupSidePanels();
   },
 
   onUnapplyTheme: function(iframeWin, newTheme) {
+    BaseOverlay.prototype.onUnapplyTheme.apply(this, arguments);
+
+    Trace.sysout("InspectorOverlay.onUnapplyTheme;", iframeWin);
+
     removeSheet(iframeWin, "chrome://firebug/skin/inspector.css", "author");
     removeSheet(iframeWin, "chrome://firebug-os/skin/inspector.css", "author");
 
@@ -141,10 +141,6 @@ const InspectorOverlay = Class(
     this.toggleSideBar.destroy();
 
     this.removeSidePanels();
-
-    Win.loaded(iframeWin).then(doc => {
-      this.updateSearchBox(false);
-    });
   },
 
   // Framework events
@@ -163,6 +159,9 @@ const InspectorOverlay = Class(
     // Unapply search-box customization when the Inspector panel
     // is hidden (unselected). The search box is shared among
     // panels and other customization can apply.
+    //
+    // xxxFlorent: It is the only place where updateSearchBox is called in
+    // onShow/onHide. Is this really required specifically here?
     this.updateSearchBox(false);
   },
 

--- a/lib/inspector/inspector-overlay.js
+++ b/lib/inspector/inspector-overlay.js
@@ -143,28 +143,6 @@ const InspectorOverlay = Class(
     this.removeSidePanels();
   },
 
-  // Framework events
-
-  onShow: function() {
-    BaseOverlay.prototype.onShow.apply(this, arguments);
-
-    if (Theme.isFirebugActive()) {
-      this.updateSearchBox(true);
-    }
-  },
-
-  onHide: function() {
-    BaseOverlay.prototype.onHide.apply(this, arguments);
-
-    // Unapply search-box customization when the Inspector panel
-    // is hidden (unselected). The search box is shared among
-    // panels and other customization can apply.
-    //
-    // xxxFlorent: It is the only place where updateSearchBox is called in
-    // onShow/onHide. Is this really required specifically here?
-    this.updateSearchBox(false);
-  },
-
   // Search
 
   updateSearchBox: function(apply) {
@@ -190,6 +168,10 @@ const InspectorOverlay = Class(
 
       this.panel.setupSearchBox();
     });
+  },
+
+  onSearch: function(value) {
+    this.search("#inspector-searchbox", value);
   },
 
   /**

--- a/lib/net/network-overlay.js
+++ b/lib/net/network-overlay.js
@@ -25,6 +25,7 @@ const NetworkOverlay = Class(
   extends: BaseOverlay,
 
   overlayId: "netmonitor",
+  searchable: true,
 
   // Initialization
   initialize: function(options) {
@@ -69,6 +70,8 @@ const NetworkOverlay = Class(
   // Theme
 
   onApplyTheme: function(win, oldTheme) {
+    BaseOverlay.prototype.onApplyTheme.apply(this, arguments);
+
     Trace.sysout("networkOverlay.onApplyTheme;");
 
     // Remove the light theme support and load Network panel
@@ -93,6 +96,8 @@ const NetworkOverlay = Class(
   },
 
   onUnapplyTheme: function(win, newTheme) {
+    BaseOverlay.prototype.onUnapplyTheme.apply(this, arguments);
+
     Trace.sysout("networkOverlay.onUnapplyTheme;");
 
     removeSheet(win, "chrome://firebug/skin/panel-content.css", "author");
@@ -246,6 +251,34 @@ const NetworkOverlay = Class(
     buttons.push("-");
 
     return buttons;
+  },
+
+  updateSearchBox: function(apply) {
+    let doc = this.getPanelDocument();
+
+    // TODO test this
+    if (apply) {
+      // Copy search box value from the original search box.
+      let netSearchBox =
+        doc.querySelector("#requests-menu-filter-freetext-text");
+      let overlay = this.chrome.getOverlay(this.toolbox,
+        "FirebugToolboxOverlay");
+      overlay.searchBox.setValue(netSearchBox.value);
+    } else {
+    }
+  },
+
+  onSearch: function(value) {
+    let doc = this.getPanelDocument();
+    let win = this.getPanelWindow();
+    let requestsMenu = win.NetMonitorView.RequestsMenu;
+
+    // xxxHonza: The search box UI will be built-in at some point
+    // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1026479
+    // As soon as the bug is fixed this code will change TESTME
+    let netSearchBox = doc.querySelector("#requests-menu-filter-freetext-text");
+    netSearchBox.value = value;
+    requestsMenu.requestsFreetextFilterEvent();
   },
 
   // Commands

--- a/lib/net/network-overlay.js
+++ b/lib/net/network-overlay.js
@@ -269,16 +269,7 @@ const NetworkOverlay = Class(
   },
 
   onSearch: function(value) {
-    let doc = this.getPanelDocument();
-    let win = this.getPanelWindow();
-    let requestsMenu = win.NetMonitorView.RequestsMenu;
-
-    // xxxHonza: The search box UI will be built-in at some point
-    // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1026479
-    // As soon as the bug is fixed this code will change TESTME
-    let netSearchBox = doc.querySelector("#requests-menu-filter-freetext-text");
-    netSearchBox.value = value;
-    requestsMenu.requestsFreetextFilterEvent();
+    this.search("#requests-menu-filter-freetext-text", value);
   },
 
   // Commands


### PR DESCRIPTION
This PR:
- Fixes issue #434 
- Factorize and simplify the code to handle the search in searchable panels
- Let the native filter box do the job (Firebug only send a `xulcommandevent` event). This also allows us to get rid of the timer of the search box

Florent
